### PR TITLE
refactor!: update to id token instead of access token

### DIFF
--- a/Dreams.xcodeproj/project.pbxproj
+++ b/Dreams.xcodeproj/project.pbxproj
@@ -185,7 +185,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1200;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1220;
 				ORGANIZATIONNAME = "Dreams AB";
 				TargetAttributes = {
 					FA343FEB251CDD950073F33E = {

--- a/Dreams.xcodeproj/xcshareddata/xcschemes/Dreams.xcscheme
+++ b/Dreams.xcodeproj/xcshareddata/xcschemes/Dreams.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Dreams.xcodeproj/xcshareddata/xcschemes/DreamsTests.xcscheme
+++ b/Dreams.xcodeproj/xcshareddata/xcschemes/DreamsTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Example/DreamsViewController.swift
+++ b/Example/Example/DreamsViewController.swift
@@ -24,7 +24,7 @@ final class DreamsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        dreamsView.open(accessToken: "accessToken", locale: Locale.current)
+        dreamsView.open(idToken: "idToken", locale: Locale.current)
     }
 
     @objc
@@ -35,8 +35,8 @@ final class DreamsViewController: UIViewController {
 
 extension DreamsViewController: DreamsViewDelegate {
 
-    func dreamsViewDelegateDidReceiveAccessTokenExpired(view: DreamsView) {
-        // set new accesstoken
+    func dreamsViewDelegateDidReceiveIdTokenExpired(view: DreamsView) {
+        // set new idToken
     }
 
     func dreamsViewDelegateDidReceiveOffboardingCompleted(view: DreamsView) {

--- a/Sources/DreamsEvent.swift
+++ b/Sources/DreamsEvent.swift
@@ -17,7 +17,7 @@ enum DreamsEvent {
      The javascript request events supported.
      */
     enum Request: String {
-        case updateAccessToken
+        case updateIdToken
         case updateLocale
     }
 
@@ -25,7 +25,7 @@ enum DreamsEvent {
      The javascript response events supported.
      */
     enum Response: String, CaseIterable {
-        case onAccessTokenDidExpired
+        case onIdTokenDidExpire
         case onOnboardingDidComplete
     }
 }

--- a/Sources/DreamsView.swift
+++ b/Sources/DreamsView.swift
@@ -38,22 +38,22 @@ public class DreamsView: UIView {
 
 extension DreamsView: DreamsViewType {
 
-    public func open(accessToken: String, locale: Locale) {
+    public func open(idToken: String, locale: Locale) {
         guard
             let clientId = dreams.clientId,
             let baseURL = dreams.baseURL else { return }
 
         let body = [
-            "accessToken": accessToken,
+            "idToken": idToken,
             "locale": locale.identifier,
             "clientId": clientId
         ]
         dreamsWebService.load(url: baseURL, method: "POST", body: body)
     }
 
-    public func update(accessToken: String) {
-        let jsonObject: JSONObject = ["accessToken": accessToken]
-        send(event: .updateAccessToken, with: jsonObject)
+    public func update(idToken: String) {
+        let jsonObject: JSONObject = ["idToken": idToken]
+        send(event: .updateIdToken, with: jsonObject)
     }
 
     public func update(locale: Locale) {
@@ -93,8 +93,8 @@ private extension DreamsView {
 
     func handle(event: DreamsEvent.Response, with jsonObject: JSONObject?) {
         switch event {
-        case .onAccessTokenDidExpired:
-            delegate?.dreamsViewDelegateDidReceiveAccessTokenExpired(view: self)
+        case .onIdTokenDidExpire:
+            delegate?.dreamsViewDelegateDidReceiveIdTokenExpired(view: self)
         case .onOnboardingDidComplete:
             delegate?.dreamsViewDelegateDidReceiveOffboardingCompleted(view: self)
         }

--- a/Sources/DreamsViewDelegate.swift
+++ b/Sources/DreamsViewDelegate.swift
@@ -18,10 +18,10 @@ import Foundation
 public protocol DreamsViewDelegate: class {
 
     /**
-     Delegate callback when the access token has expired.
+     Delegate callback when the idToken has expired.
      - parameter view: The dreams view invoking the delegate method.
      */
-    func dreamsViewDelegateDidReceiveAccessTokenExpired(view: DreamsView)
+    func dreamsViewDelegateDidReceiveIdTokenExpired(view: DreamsView)
 
     /**
      Delegate callback when an offboarding has been completed.

--- a/Sources/DreamsViewType.swift
+++ b/Sources/DreamsViewType.swift
@@ -15,16 +15,16 @@ public protocol DreamsViewType {
 
     /**
      Open the dreams view.
-     - parameter accessToken: The accessToken.
+     - parameter idToken: The idToken.
      - parameter locale: The users locale.
      */
-    func open(accessToken: String, locale: Locale)
+    func open(idToken: String, locale: Locale)
 
     /**
-     Update the accessToken.
-     - parameter accessToken: The new accessToken.
+     Update the idToken.
+     - parameter idToken: The new idToken.
      */
-    func update(accessToken: String)
+    func update(idToken: String)
 
     /**
      Update the locale.

--- a/Tests/DreamsViewDelegateSpy.swift
+++ b/Tests/DreamsViewDelegateSpy.swift
@@ -14,11 +14,11 @@ import Foundation
 
 class DreamsViewDelegateSpy: DreamsViewDelegate {
 
-    var accessTokenExpiredWasCalled: Bool = false
+    var idTokenExpiredWasCalled: Bool = false
     var offboardingWasCalled: Bool = false
 
-    func dreamsViewDelegateDidReceiveAccessTokenExpired(view: DreamsView) {
-        accessTokenExpiredWasCalled = true
+    func dreamsViewDelegateDidReceiveIdTokenExpired(view: DreamsView) {
+        idTokenExpiredWasCalled = true
     }
 
     func dreamsViewDelegateDidReceiveOffboardingCompleted(view: DreamsView) {

--- a/Tests/DreamsViewTests.swift
+++ b/Tests/DreamsViewTests.swift
@@ -34,8 +34,8 @@ class DreamsViewTests: XCTestCase {
         let delegate = DreamsViewDelegateSpy()
         dreamsView.delegate = delegate
 
-        service.handleResponseMessage(name: "onAccessTokenDidExpired", body: nil)
-        XCTAssertTrue(delegate.accessTokenExpiredWasCalled)
+        service.handleResponseMessage(name: "onIdTokenDidExpire", body: nil)
+        XCTAssertTrue(delegate.idTokenExpiredWasCalled)
 
         service.handleResponseMessage(name: "onOnboardingDidComplete", body: nil)
         XCTAssertTrue(delegate.offboardingWasCalled)
@@ -47,12 +47,12 @@ class DreamsViewTests: XCTestCase {
 
         let dreamsView = DreamsView()
         dreamsView.dreamsWebService.delegate = delegate
-        dreamsView.open(accessToken: "accessToken", locale: locale)
+        dreamsView.open(idToken: "idToken", locale: locale)
 
         let event = delegate.events.last
         let request = event?["request"] as! URLRequest
         let httpBody = try! JSONSerialization.jsonObject(with: request.httpBody!) as! [String : Any]
-        let expectedBody: [String: Any] = ["accessToken": "accessToken", "locale": "sv_SE", "clientId": "clientId"]
+        let expectedBody: [String: Any] = ["idToken": "idToken", "locale": "sv_SE", "clientId": "clientId"]
 
         XCTAssertEqual(delegate.events.count, 1)
         XCTAssertEqual(request.url?.absoluteString, "https://www.getdreams.com")
@@ -60,23 +60,23 @@ class DreamsViewTests: XCTestCase {
         XCTAssertEqual(NSDictionary(dictionary: expectedBody), NSDictionary(dictionary: httpBody))
     }
 
-    func testUpdateAccessTokenRequest() {
+    func testUpdateIdTokenRequest() {
         let service = DreamsWebServiceSpy()
         let dreamsView = DreamsView()
         dreamsView.dreamsWebService = service
         dreamsView.dreamsWebService.delegate = dreamsView
-        dreamsView.update(accessToken: "anotherAccessToken")
+        dreamsView.update(idToken: "anotherIdToken")
 
         let event = service.events.last
         let type = event?["event"] as! DreamsEvent.Request
         let jsonObject = event?["jsonObject"] as! JSONObject
 
         XCTAssertEqual(service.events.count, 1)
-        XCTAssertEqual(type, .updateAccessToken)
-        XCTAssertEqual(jsonObject["accessToken"] as! String, "anotherAccessToken")
+        XCTAssertEqual(type, .updateIdToken)
+        XCTAssertEqual(jsonObject["idToken"] as! String, "anotherIdToken")
     }
 
-    func testUpdateAccessTokenJSMessage() {
+    func testUpdateIdTokenJSMessage() {
         let spyDelegate = DreamsWebServiceDelegateSpy()
         let service = DreamsWebServiceSpy()
 
@@ -85,11 +85,11 @@ class DreamsViewTests: XCTestCase {
         dreamsView.dreamsWebService.delegate = dreamsView
 
         service.delegate = spyDelegate
-        dreamsView.update(accessToken: "anotherAccessToken")
+        dreamsView.update(idToken: "anotherIdToken")
 
         let event = spyDelegate.events.last
         let message = event?["message"] as! String
-        let expectedJSMessage = "updateAccessToken('{\"accessToken\":\"anotherAccessToken\"}')"
+        let expectedJSMessage = "updateIdToken('{\"idToken\":\"anotherIdToken\"}')"
         XCTAssertEqual(expectedJSMessage, message)
         XCTAssertEqual(service.events.count, 1)
     }

--- a/Tests/DreamsWebServiceTests.swift
+++ b/Tests/DreamsWebServiceTests.swift
@@ -61,12 +61,12 @@ class DreamsWebServiceTests: XCTestCase {
         let service = DreamsWebService()
         service.delegate = spyDelegate
 
-        let jsonObject: JSONObject = ["accessToken": "someAccessToken"]
-        service.prepareRequestMessage(event: .updateAccessToken, with: jsonObject)
+        let jsonObject: JSONObject = ["idToken": "someIdToken"]
+        service.prepareRequestMessage(event: .updateIdToken, with: jsonObject)
 
         let event = spyDelegate.events.last
         let message = event?["message"] as! String
-        let expectedMessage = "updateAccessToken('{\"accessToken\":\"someAccessToken\"}')"
+        let expectedMessage = "updateIdToken('{\"idToken\":\"someIdToken\"}')"
 
         XCTAssertEqual(message, expectedMessage)
     }
@@ -75,11 +75,11 @@ class DreamsWebServiceTests: XCTestCase {
         let spyDelegate = DreamsWebServiceDelegateSpy()
         let service = DreamsWebService()
         service.delegate = spyDelegate
-        service.handleResponseMessage(name: "onAccessTokenDidExpired", body: nil)
+        service.handleResponseMessage(name: "onIdTokenDidExpire", body: nil)
 
         let event = spyDelegate.events.last
         let eventResponseType = event?["event"] as! DreamsEvent.Response
         
-        XCTAssertEqual(eventResponseType, .onAccessTokenDidExpired)
+        XCTAssertEqual(eventResponseType, .onIdTokenDidExpire)
     }
 }


### PR DESCRIPTION
#### Description
- update to use `idToken` instead of `accessToken` when communicating with the PWA.