### PR TITLE
feat(telemetry): add callback when a telemetry event has been received

### DIFF
--- a/Example/Example/DreamsViewController.swift
+++ b/Example/Example/DreamsViewController.swift
@@ -39,6 +39,10 @@ extension DreamsViewController: DreamsViewDelegate {
         // set new idToken
     }
 
+    func dreamsViewDelegateDidReceiveTelemetryEvent(view: DreamsView, name: String, payload: [String : Any]) {
+        // telemetry event received
+    }
+
     func dreamsViewDelegateDidReceiveOffboardingCompleted(view: DreamsView) {
         // offboarding 
     }

--- a/Sources/DreamsEvent.swift
+++ b/Sources/DreamsEvent.swift
@@ -26,6 +26,7 @@ enum DreamsEvent {
      */
     enum Response: String, CaseIterable {
         case onIdTokenDidExpire
+        case onTelemetryEvent
         case onOnboardingDidComplete
     }
 }

--- a/Sources/DreamsView.swift
+++ b/Sources/DreamsView.swift
@@ -48,6 +48,7 @@ extension DreamsView: DreamsViewType {
             "locale": locale.identifier,
             "clientId": clientId
         ]
+
         dreamsWebService.load(url: baseURL, method: "POST", body: body)
     }
 
@@ -95,6 +96,11 @@ private extension DreamsView {
         switch event {
         case .onIdTokenDidExpire:
             delegate?.dreamsViewDelegateDidReceiveIdTokenExpired(view: self)
+        case .onTelemetryEvent:
+            guard let name = jsonObject?["name"] as? String,
+                  let payload = jsonObject?["payload"] as? JSONObject else { return }
+
+            delegate?.dreamsViewDelegateDidReceiveTelemetryEvent(view: self, name: name, payload: payload)
         case .onOnboardingDidComplete:
             delegate?.dreamsViewDelegateDidReceiveOffboardingCompleted(view: self)
         }

--- a/Sources/DreamsViewDelegate.swift
+++ b/Sources/DreamsViewDelegate.swift
@@ -24,6 +24,14 @@ public protocol DreamsViewDelegate: class {
     func dreamsViewDelegateDidReceiveIdTokenExpired(view: DreamsView)
 
     /**
+     Delegate callback when a telemetry event is received.
+     - parameter view: The dreams view invoking the delegate method.
+     - parameter name: The name of the received telemetry event.
+     - parameter payload: The payload containing telemetry event data.
+     */
+    func dreamsViewDelegateDidReceiveTelemetryEvent(view: DreamsView, name: String, payload: [String: Any])
+
+    /**
      Delegate callback when an offboarding has been completed.
      - parameter view: The dreams view invoking the delegate method.
      */

--- a/Tests/DreamsViewDelegateSpy.swift
+++ b/Tests/DreamsViewDelegateSpy.swift
@@ -15,10 +15,19 @@ import Foundation
 class DreamsViewDelegateSpy: DreamsViewDelegate {
 
     var idTokenExpiredWasCalled: Bool = false
+    var telemetryEventWasCalled: Bool = false
     var offboardingWasCalled: Bool = false
+
+    var telemetryEvents: [[String: Any]] = []
 
     func dreamsViewDelegateDidReceiveIdTokenExpired(view: DreamsView) {
         idTokenExpiredWasCalled = true
+    }
+
+    func dreamsViewDelegateDidReceiveTelemetryEvent(view: DreamsView, name: String, payload: [String: Any]) {
+        telemetryEventWasCalled = true
+        let telemetryEvent: [String: Any] = ["name": name, "payload": payload]
+        telemetryEvents.append(telemetryEvent)
     }
 
     func dreamsViewDelegateDidReceiveOffboardingCompleted(view: DreamsView) {

--- a/Tests/DreamsViewTests.swift
+++ b/Tests/DreamsViewTests.swift
@@ -37,6 +37,16 @@ class DreamsViewTests: XCTestCase {
         service.handleResponseMessage(name: "onIdTokenDidExpire", body: nil)
         XCTAssertTrue(delegate.idTokenExpiredWasCalled)
 
+        service.handleResponseMessage(name: "onTelemetryEvent", body: ["name": "test_event", "payload": ["test": "test"]])
+        XCTAssertTrue(delegate.telemetryEventWasCalled)
+
+        let lastTelemetryEvent = delegate.telemetryEvents.last
+        let name = lastTelemetryEvent?["name"] as? String
+        let payload = lastTelemetryEvent?["payload"] as? [String: Any]
+
+        XCTAssertEqual(name, "test_event")
+        XCTAssertEqual(NSDictionary(dictionary: payload!), NSDictionary(dictionary: ["test": "test"]))
+
         service.handleResponseMessage(name: "onOnboardingDidComplete", body: nil)
         XCTAssertTrue(delegate.offboardingWasCalled)
     }


### PR DESCRIPTION
Adds `onTelemetryEvent` response event that will trigger a new delegate method on the `DreamsViewDelegate` to be called with a name and payload containing the telemetry event data.