### PR TITLE
Add completion with result to launch method

### DIFF
--- a/Dreams.xcodeproj/project.pbxproj
+++ b/Dreams.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		1A0C2C9C25AC9C9100279C0C /* DreamsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0C2C9B25AC9C9100279C0C /* DreamsCredentials.swift */; };
 		1A0C2CB425ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */; };
 		1A0C2CCE25AF59A700279C0C /* WebViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */; };
+		1A4E0C7B25B87F5000D453B1 /* DreamsLaunchingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */; };
+		1A4E0D9025C0599A00D453B1 /* FakeResponseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4E0D8F25C0599A00D453B1 /* FakeResponseMock.swift */; };
+		1AA0023625C05FF4000C5883 /* MockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA0023525C05FF4000C5883 /* MockNavigation.swift */; };
 		1AAC42C025B0928200A56457 /* WebViewSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAC42BF25B0928200A56457 /* WebViewSpy.swift */; };
 		1AAC42C325B0970700A56457 /* DreamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6CD92B25262F7E00E68FA7 /* DreamsTests.swift */; };
 		1AAC42C625B0989000A56457 /* DreamsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6CD92725262F1600E68FA7 /* DreamsViewControllerTests.swift */; };
@@ -50,6 +53,9 @@
 		1A0C2C9B25AC9C9100279C0C /* DreamsCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsCredentials.swift; sourceTree = "<group>"; };
 		1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsNetworkInteractionBuilder.swift; sourceTree = "<group>"; };
 		1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProtocol.swift; sourceTree = "<group>"; };
+		1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsLaunchingError.swift; sourceTree = "<group>"; };
+		1A4E0D8F25C0599A00D453B1 /* FakeResponseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeResponseMock.swift; sourceTree = "<group>"; };
+		1AA0023525C05FF4000C5883 /* MockNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigation.swift; sourceTree = "<group>"; };
 		1AAC42BF25B0928200A56457 /* WebViewSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewSpy.swift; sourceTree = "<group>"; };
 		1AAC42C925B0993800A56457 /* DreamsNetworkInteractingSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsNetworkInteractingSpy.swift; sourceTree = "<group>"; };
 		1AAC42CF25B09BF800A56457 /* DreamsNetworkInteractionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsNetworkInteractionBuilderTests.swift; sourceTree = "<group>"; };
@@ -107,6 +113,15 @@
 			path = Spies;
 			sourceTree = "<group>";
 		};
+		1A4E0D8E25C0597600D453B1 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				1A4E0D8F25C0599A00D453B1 /* FakeResponseMock.swift */,
+				1AA0023525C05FF4000C5883 /* MockNavigation.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		FA343FE2251CDD950073F33E = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +159,7 @@
 				FAF52DFF252F2ADE0099D38F /* WebServiceDelegate.swift */,
 				1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */,
 				1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */,
+				1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -156,6 +172,7 @@
 				FA7378342588F0B300B662F3 /* DreamsNetworkInteractionTests.swift */,
 				FA6CD92725262F1600E68FA7 /* DreamsViewControllerTests.swift */,
 				FA6CD8E12525EB2700E68FA7 /* WebServiceTests.swift */,
+				1A4E0D8E25C0597600D453B1 /* Mocks */,
 				1A0C2CC825AF562700279C0C /* Spies */,
 				FA6CD8E32525EB2700E68FA7 /* Info.plist */,
 			);
@@ -272,6 +289,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1A4E0C7B25B87F5000D453B1 /* DreamsLaunchingError.swift in Sources */,
 				1A0C2C9C25AC9C9100279C0C /* DreamsCredentials.swift in Sources */,
 				1A0C2CB425ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift in Sources */,
 				FA482EA3251CE91F00D6006B /* DreamsViewController.swift in Sources */,
@@ -293,6 +311,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1AAC42C625B0989000A56457 /* DreamsViewControllerTests.swift in Sources */,
+				1AA0023625C05FF4000C5883 /* MockNavigation.swift in Sources */,
 				1AAC42C325B0970700A56457 /* DreamsTests.swift in Sources */,
 				FA6CD948252C6A9900E68FA7 /* WebServiceSpy.swift in Sources */,
 				FA6CD941252C6A8000E68FA7 /* DreamsDelegateSpy.swift in Sources */,
@@ -301,6 +320,7 @@
 				FA6CD953252C6AF700E68FA7 /* WebServiceDelegateSpy.swift in Sources */,
 				FA6CD8E22525EB2700E68FA7 /* WebServiceTests.swift in Sources */,
 				1AAC42CA25B0993800A56457 /* DreamsNetworkInteractingSpy.swift in Sources */,
+				1A4E0D9025C0599A00D453B1 /* FakeResponseMock.swift in Sources */,
 				FAABFF482588F2BE00302A40 /* DreamsNetworkInteractionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -6,12 +6,29 @@ import Dreams
 //
 class ViewController: UIViewController {
     @IBAction func presentDreams() {
-        let vc = DreamsViewController()
-        vc.use(delegate: self)
-        let nvc = UINavigationController(rootViewController: vc)
-        nvc.modalPresentationStyle = .fullScreen
-        present(nvc, animated: true) {
-            vc.launch(with: DreamsCredentials(idToken: "idToken"), locale: Locale.current)
+        let viewController = DreamsViewController()
+        let userCredentials = DreamsCredentials(idToken: "idToken")
+        viewController.use(delegate: self)
+        let navigation = UINavigationController(rootViewController: viewController)
+        navigation.modalPresentationStyle = .fullScreen
+        present(navigation, animated: true) {
+            viewController.launch(with: userCredentials, locale: Locale.current) { result in
+                switch result {
+                case .success:
+                    () // Dreams did launch successfully
+                case .failure(let launchError):
+                    switch launchError {
+                    case .alreadyLaunched:
+                        () // You cannot launch Dreams when launching is in progess
+                    case .invalidCredentials:
+                        () // The provided credentials were invalid
+                    case .httpErrorStatus(let httpStatus):
+                        print(httpStatus) // The server returned a HTTP error status
+                    case .requestFailure(let error):
+                        print(error) // Other server errors (NSError instance)
+                    }
+                }
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,23 @@ let userCredentials = DreamsCredentials(idToken: "idToken")
 ```swift
 let navigation = UINavigationController(rootViewController: viewController)
 present(navigation, animated: true) {
-    viewController.launch(with: userCredentials)
+    viewController.launch(with: userCredentials, locale: Locale.current) { result in
+        switch result {
+        case .success:
+            () // Dreams did launch successfully
+        case .failure(let launchError):
+            switch launchError {
+            case .alreadyLaunched:
+                () // You cannot launch Dreams when launching is in progess
+            case .invalidCredentials:
+                () // The provided credentials were invalid
+            case .httpErrorStatus(let httpStatus):
+                print(httpStatus) // The server returned a HTTP error status
+            case .requestFailure(let error):
+                print(error) // Other server errors (NSError instance)
+            }
+        }
+    }
 }
 
 ```

--- a/Sources/DreamsLaunchingError.swift
+++ b/Sources/DreamsLaunchingError.swift
@@ -1,0 +1,19 @@
+//
+//  DreamsLaunchingError
+//  Dreams
+//
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright © 2021 Dreams AB.
+//
+
+import Foundation
+
+public enum DreamsLaunchingError: Error, Equatable {
+    case alreadyLaunched
+    case invalidCredentials
+    case httpErrorStatus(Int)
+    case requestFailure(NSError)
+}

--- a/Sources/DreamsNetworkInteraction.swift
+++ b/Sources/DreamsNetworkInteraction.swift
@@ -10,6 +10,7 @@
 //
 
 import Foundation
+import WebKit
 
 // MARK: DreamsNetworkInteracting
 
@@ -17,8 +18,14 @@ public protocol DreamsNetworkInteracting {
     func didLoad()
     func use(webView: WebViewProtocol)
     func use(delegate: DreamsDelegate)
-    func launch(with credentials: DreamsCredentials, locale: Locale)
+    func launch(with credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?)
     func update(locale: Locale)
+}
+
+extension DreamsNetworkInteracting {
+    func launch(with credentials: DreamsCredentials, locale: Locale) {
+        launch(with: credentials, locale: locale, completion: nil)
+    }
 }
 
 // MARK: DreamsNetworkInteraction
@@ -45,14 +52,15 @@ public final class DreamsNetworkInteraction: DreamsNetworkInteracting {
     public func use(webView: WebViewProtocol) {
         self.webView = webView
         setUpUserContentController()
+        setUpNavigationDelegate()
     }
     
     public func use(delegate: DreamsDelegate) {
         self.delegate = delegate
     }
     
-    public func launch(with credentials: DreamsCredentials, locale: Locale) {
-        loadBaseURL(credentials: credentials, locale: locale)
+    public func launch(with credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?) {
+        loadBaseURL(credentials: credentials, locale: locale, completion: completion)
     }
     
     public func update(locale: Locale) {
@@ -99,7 +107,11 @@ public final class DreamsNetworkInteraction: DreamsNetworkInteracting {
         }
     }
     
-    private func loadBaseURL(credentials: DreamsCredentials, locale: Locale) {
+    private func setUpNavigationDelegate() {
+        webView.navigationDelegate = webService
+    }
+    
+    private func loadBaseURL(credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?) {
     
         let body = [
             "token": credentials.idToken,
@@ -109,7 +121,7 @@ public final class DreamsNetworkInteraction: DreamsNetworkInteracting {
         
         let verifyTokenURL = configuration.baseURL.appendingPathComponent("/users/verify_token")
 
-        webService.load(url: verifyTokenURL, method: "POST", body: body)
+        webService.load(url: verifyTokenURL, method: "POST", body: body, completion: completion)
     }
 }
 

--- a/Sources/DreamsViewController.swift
+++ b/Sources/DreamsViewController.swift
@@ -15,10 +15,29 @@ import WebKit
 public protocol DreamsLaunching: class {
     /**
      This method MUST be called just after the DreamsViewController is presented, the Dreams interface will be launched for given credentials.
+     
      - parameter idToken: User idToken
      - parameter locale: Selected Locale
+     - parameter completion: Called when Dreams did launch successfuly or failed
+     
+     - Attention: This method MUST be called on main thread, when called from background threads it will crash to avoid undefined behaviour.
+        
      */
-    func launch(with credentials: DreamsCredentials, locale: Locale)
+    func launch(with credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?)
+}
+
+public extension DreamsLaunching {
+    /**
+     This method MUST be called just after the DreamsViewController is presented, the Dreams interface will be launched for given credentials.
+
+     - parameter idToken: User idToken
+     - parameter locale: Selected Locale
+     
+     - Attention: This method MUST be called on main thread, when called from background threads it will crash to avoid undefined behaviour.
+     */
+    func launch(with credentials: DreamsCredentials, locale: Locale) {
+        launch(with: credentials, locale: locale, completion: nil)
+    }
 }
 
 public protocol LocaleUpdating: class {
@@ -84,11 +103,19 @@ extension DreamsViewController: DreamsLaunching {
 
     /**
      This method MUST be called just after the DreamsViewController is presented, the Dreams interface will be launched for given credentials.
+     
      - parameter idToken: User idToken
      - parameter locale: Selected Locale
+     - parameter completion: Called when Dreams did launch successfuly or failed
+    
+     - Attention: This method MUST be called on main thread, when called from background threads it will crash to avoid undefined behaviour.
+        
      */
-    public func launch(with credentials: DreamsCredentials, locale: Locale) {
-        interaction.launch(with: credentials, locale: locale)
+    public func launch(with credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?) {
+        guard Thread.isMainThread else {
+            fatalError("Launch can be only called on main thread!")
+        }
+        interaction.launch(with: credentials, locale: locale, completion: completion)
     }
 }
 

--- a/Sources/WebServiceType.swift
+++ b/Sources/WebServiceType.swift
@@ -12,7 +12,7 @@
 import Foundation
 import WebKit
 
-protocol WebServiceType: WKScriptMessageHandler {
+protocol WebServiceType: WKScriptMessageHandler, WKNavigationDelegate  {
 
     /**
      The object that acts as the delegate of the web service.
@@ -28,7 +28,7 @@ protocol WebServiceType: WKScriptMessageHandler {
      # Notes: #
      If the delegate property is set, calling this function will trigger the `webServiceDidPrepareRequest:service:urlRequest: delegate callback`
      */
-    func load(url: URL, method: String, body: JSONObject?)
+    func load(url: URL, method: String, body: JSONObject?, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?)
 
     /**
      Prepare request message to be sent to the web view.

--- a/Sources/WebViewProtocol.swift
+++ b/Sources/WebViewProtocol.swift
@@ -1,5 +1,4 @@
 //
-//  WebViewAdapter
 //  Dreams
 //
 //  This Source Code Form is subject to the terms of the Mozilla Public
@@ -14,6 +13,7 @@ import WebKit
 
 public protocol WebViewProtocol: AnyObject {
     var configuration: WKWebViewConfiguration { get }
+    var navigationDelegate: WKNavigationDelegate? { get set }
     func add(_ scriptMessageHandler: WKScriptMessageHandler, name: String)
     func load(_ request: URLRequest) -> WKNavigation?
     func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)?)

--- a/Tests/DreamsNetworkInteractionTests.swift
+++ b/Tests/DreamsNetworkInteractionTests.swift
@@ -59,6 +59,28 @@ final class DreamsNetworkInteractionTests: XCTestCase {
         XCTAssertEqual(NSDictionary(dictionary: expectedBody), NSDictionary(dictionary: httpBody))
     }
     
+    func test_launch_passedCompletionToWebService() {
+        let completion: (Result<Void, DreamsLaunchingError>) -> Void = { result in
+            
+        }
+
+        subject.launch(with: DreamsCredentials(idToken: "idToken"), locale: Locale(identifier: "sv_SE"), completion: completion)
+
+        XCTAssertEqual(service.completions.count, 1)
+    }
+    
+    func test_launch_sucess_notified() {
+        var called = false
+        let completion: (Result<Void, DreamsLaunchingError>) -> Void = { result in
+            called = true
+        }
+
+        subject.launch(with: DreamsCredentials(idToken: "idToken"), locale: Locale(identifier: "sv_SE"), completion: completion)
+        service.completions.first!(.success(()))
+        
+        XCTAssertTrue(called)
+    }
+    
     func test_webServiceDidPrepareRequest_requestedWebView() {
         let request = URLRequest(url: URL(string: "https://www.getdreams.com")!)
         subject.webServiceDidPrepareRequest(service: service, urlRequest: request)

--- a/Tests/Mocks/FakeResponseMock.swift
+++ b/Tests/Mocks/FakeResponseMock.swift
@@ -1,0 +1,34 @@
+//
+//  FakeResponseMock
+//  DreamsTests
+//
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright © 2021 Dreams AB.
+//
+
+import Foundation
+import WebKit
+
+class FakeResponseMock: WKNavigationResponse {
+   
+   private let fakeResponse: URLResponse
+   
+   init(fakeResponse: URLResponse) {
+       self.fakeResponse = fakeResponse
+   }
+   
+   override var isForMainFrame: Bool {
+       return true
+   }
+
+   override var response: URLResponse {
+       return fakeResponse
+   }
+
+   override var canShowMIMEType: Bool {
+       return true
+   }
+}

--- a/Tests/Mocks/MockNavigation.swift
+++ b/Tests/Mocks/MockNavigation.swift
@@ -1,0 +1,34 @@
+//
+//  File
+//  DreamsTests
+//
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright © 2021 Dreams AB.
+//
+
+import Foundation
+import WebKit
+
+
+final class MockNavigation: WKNavigation {
+    @objc dynamic public func swizzledDeinit() {
+        // nothing
+    }
+    
+    //
+    // Why? http://www.openradar.me/43934706
+    //
+    static func swizzleDeinitInWKNavigation() -> WKNavigation {
+        let navigation = MockNavigation()
+        let aClass: AnyClass! = object_getClass(navigation)
+        let originalMethod = class_getInstanceMethod(aClass, NSSelectorFromString("dealloc"))
+        let swizzledMethod = class_getInstanceMethod(aClass, #selector(MockNavigation.swizzledDeinit))
+        if let originalMethod = originalMethod, let swizzledMethod = swizzledMethod {
+            method_exchangeImplementations(originalMethod, swizzledMethod)
+        }
+        return navigation
+    }
+}

--- a/Tests/Spies/DreamsNetworkInteractingSpy.swift
+++ b/Tests/Spies/DreamsNetworkInteractingSpy.swift
@@ -13,10 +13,12 @@ import Foundation
 @testable import Dreams
 
 final class DreamsNetworkInteractingSpy: DreamsNetworkInteracting {
+
     var didLoadCount: Int = 0
     var useWebViews: [WebViewProtocol] = []
     var useDelegates: [DreamsDelegate] = []
     var launchCredentials: [DreamsCredentials] = []
+    var completions: [((Result<Void, DreamsLaunchingError>) -> Void)] = []
     var launchLocales: [Locale] = []
     var updateLocales: [Locale] = []
     
@@ -32,14 +34,15 @@ final class DreamsNetworkInteractingSpy: DreamsNetworkInteracting {
         useDelegates.append(delegate)
     }
     
-    func launch(with credentials: DreamsCredentials, locale: Locale) {
+    func launch(with credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?) {
         launchCredentials.append(credentials)
         launchLocales.append(locale)
+        if let completion = completion {
+            completions.append(completion)
+        }
     }
     
     func update(locale: Locale) {
         updateLocales.append(locale)
     }
-    
-    
 }

--- a/Tests/Spies/WebServiceSpy.swift
+++ b/Tests/Spies/WebServiceSpy.swift
@@ -14,19 +14,23 @@ import WebKit
 @testable import Dreams
 
 class WebServiceSpy: NSObject, WebServiceType {
-    
+
     var delegate: WebServiceDelegate?
     
     var events: [Request] = []
     var jsonObjects: [JSONObject] = []
+    var completions: [((Result<Void, DreamsLaunchingError>) -> Void)] = []
     
     var load_urls: [URL] = []
     var load_methods: [String] = []
     var load_bodys: [JSONObject] = []
     
-    func load(url: URL, method: String, body: JSONObject?) {
+    func load(url: URL, method: String, body: JSONObject?, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?) {
         load_urls.append(url)
         load_methods.append(method)
+        if let completion = completion {
+            completions.append(completion)
+        }
         guard let body = body else { return }
         load_bodys.append(body)
     }

--- a/Tests/Spies/WebViewSpy.swift
+++ b/Tests/Spies/WebViewSpy.swift
@@ -15,6 +15,8 @@ import WebKit
 
 final class WebViewSpy: WebViewProtocol {
     
+    var navigationDelegate: WKNavigationDelegate?
+    
     var configuration: WKWebViewConfiguration
     
     var scriptMessageHandlers: [WKScriptMessageHandler] = []


### PR DESCRIPTION
### What's new 
- New method `launch(with:locale:completion)` can be used with a closure. 
- Old `launch(with:locale:)` will still work and is not deprecated.
- Callling `launch()` from main thread is required now and failure to do that will cause `fatalError()` this is measure against race condition instead of costly synchronisation.

### Completion Closure
This closure will pass a result `Result<Void, DreamsLaunchingError>` where:

```
public enum DreamsLaunchingError: Error, Equatable {
    case alreadyLaunched
    case invalidCredentials
    case httpErrorStatus(Int)
    case requestFailure(NSError)
}
```

### Important note

Found issue with `WKNavigation` dealloc method, used swizzling to get rid of problematic objc `dealloc` method in a Mock.


