### PR TITLE
Change `locale` parameter format to BCP47

### DIFF
--- a/Dreams.xcodeproj/project.pbxproj
+++ b/Dreams.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		1A0C2CB425ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */; };
 		1A0C2CCE25AF59A700279C0C /* WebViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */; };
 		1A12D2CE25C825480022A73B /* DreamsNetworkInteracting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A12D2CD25C825480022A73B /* DreamsNetworkInteracting.swift */; };
+		1A12D2D625C828C10022A73B /* LocaleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A12D2D525C828C10022A73B /* LocaleFormatter.swift */; };
+		1A12D2DA25C95CAF0022A73B /* LocaleFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A12D2D925C95CAF0022A73B /* LocaleFormatting.swift */; };
+		1A12D2E125C95F200022A73B /* LocaleFormattingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A12D2DD25C95F0F0022A73B /* LocaleFormattingMock.swift */; };
+		1A12D2E725C96E420022A73B /* LocaleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A12D2E625C96E420022A73B /* LocaleFormatterTests.swift */; };
 		1A4E0C7B25B87F5000D453B1 /* DreamsLaunchingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */; };
 		1A4E0D9025C0599A00D453B1 /* FakeResponseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4E0D8F25C0599A00D453B1 /* FakeResponseMock.swift */; };
 		1AA0023625C05FF4000C5883 /* MockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA0023525C05FF4000C5883 /* MockNavigation.swift */; };
@@ -56,6 +60,10 @@
 		1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsNetworkInteractionBuilder.swift; sourceTree = "<group>"; };
 		1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProtocol.swift; sourceTree = "<group>"; };
 		1A12D2CD25C825480022A73B /* DreamsNetworkInteracting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsNetworkInteracting.swift; sourceTree = "<group>"; };
+		1A12D2D525C828C10022A73B /* LocaleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFormatter.swift; sourceTree = "<group>"; };
+		1A12D2D925C95CAF0022A73B /* LocaleFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFormatting.swift; sourceTree = "<group>"; };
+		1A12D2DD25C95F0F0022A73B /* LocaleFormattingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFormattingMock.swift; sourceTree = "<group>"; };
+		1A12D2E625C96E420022A73B /* LocaleFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFormatterTests.swift; sourceTree = "<group>"; };
 		1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsLaunchingError.swift; sourceTree = "<group>"; };
 		1A4E0D8F25C0599A00D453B1 /* FakeResponseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeResponseMock.swift; sourceTree = "<group>"; };
 		1AA0023525C05FF4000C5883 /* MockNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigation.swift; sourceTree = "<group>"; };
@@ -121,6 +129,7 @@
 			children = (
 				1A4E0D8F25C0599A00D453B1 /* FakeResponseMock.swift */,
 				1AA0023525C05FF4000C5883 /* MockNavigation.swift */,
+				1A12D2DD25C95F0F0022A73B /* LocaleFormattingMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -165,6 +174,8 @@
 				FA6B49CD252356E80026B31D /* WebService.swift */,
 				1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */,
 				1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */,
+				1A12D2D525C828C10022A73B /* LocaleFormatter.swift */,
+				1A12D2D925C95CAF0022A73B /* LocaleFormatting.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -176,6 +187,7 @@
 				1AAC42CF25B09BF800A56457 /* DreamsNetworkInteractionBuilderTests.swift */,
 				FA7378342588F0B300B662F3 /* DreamsNetworkInteractionTests.swift */,
 				FA6CD92725262F1600E68FA7 /* DreamsViewControllerTests.swift */,
+				1A12D2E625C96E420022A73B /* LocaleFormatterTests.swift */,
 				FA6CD8E12525EB2700E68FA7 /* WebServiceTests.swift */,
 				1A4E0D8E25C0597600D453B1 /* Mocks */,
 				1A0C2CC825AF562700279C0C /* Spies */,
@@ -298,9 +310,11 @@
 				1A0C2C9C25AC9C9100279C0C /* DreamsCredentials.swift in Sources */,
 				1A0C2CB425ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift in Sources */,
 				FA482EA3251CE91F00D6006B /* DreamsViewController.swift in Sources */,
+				1A12D2D625C828C10022A73B /* LocaleFormatter.swift in Sources */,
 				FA6B49CE252356E80026B31D /* WebService.swift in Sources */,
 				FAF52E00252F2ADE0099D38F /* WebServiceDelegate.swift in Sources */,
 				1A0C2C8E25AC7FD900279C0C /* DreamsConfiguration.swift in Sources */,
+				1A12D2DA25C95CAF0022A73B /* LocaleFormatting.swift in Sources */,
 				FA73781825876E7600B662F3 /* ResponseEvent.swift in Sources */,
 				1A0C2C8A25AC7F9F00279C0C /* DreamsNetworkInteraction.swift in Sources */,
 				FAF52E04252F2FC90099D38F /* WebServiceType.swift in Sources */,
@@ -321,8 +335,10 @@
 				1AAC42C325B0970700A56457 /* DreamsTests.swift in Sources */,
 				FA6CD948252C6A9900E68FA7 /* WebServiceSpy.swift in Sources */,
 				FA6CD941252C6A8000E68FA7 /* DreamsDelegateSpy.swift in Sources */,
+				1A12D2E125C95F200022A73B /* LocaleFormattingMock.swift in Sources */,
 				1AAC42C025B0928200A56457 /* WebViewSpy.swift in Sources */,
 				1AAC42D025B09BF800A56457 /* DreamsNetworkInteractionBuilderTests.swift in Sources */,
+				1A12D2E725C96E420022A73B /* LocaleFormatterTests.swift in Sources */,
 				FA6CD953252C6AF700E68FA7 /* WebServiceDelegateSpy.swift in Sources */,
 				FA6CD8E22525EB2700E68FA7 /* WebServiceTests.swift in Sources */,
 				1AAC42CA25B0993800A56457 /* DreamsNetworkInteractingSpy.swift in Sources */,

--- a/Dreams.xcodeproj/project.pbxproj
+++ b/Dreams.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1A0C2C9C25AC9C9100279C0C /* DreamsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0C2C9B25AC9C9100279C0C /* DreamsCredentials.swift */; };
 		1A0C2CB425ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */; };
 		1A0C2CCE25AF59A700279C0C /* WebViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */; };
+		1A12D2CE25C825480022A73B /* DreamsNetworkInteracting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A12D2CD25C825480022A73B /* DreamsNetworkInteracting.swift */; };
 		1A4E0C7B25B87F5000D453B1 /* DreamsLaunchingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */; };
 		1A4E0D9025C0599A00D453B1 /* FakeResponseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4E0D8F25C0599A00D453B1 /* FakeResponseMock.swift */; };
 		1AA0023625C05FF4000C5883 /* MockNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA0023525C05FF4000C5883 /* MockNavigation.swift */; };
@@ -48,11 +49,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1A02FC0025C19DBC0080A67E /* Dreams.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Dreams.podspec; sourceTree = "<group>"; };
 		1A0C2C8925AC7F9F00279C0C /* DreamsNetworkInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsNetworkInteraction.swift; sourceTree = "<group>"; };
 		1A0C2C8D25AC7FD900279C0C /* DreamsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsConfiguration.swift; sourceTree = "<group>"; };
 		1A0C2C9B25AC9C9100279C0C /* DreamsCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsCredentials.swift; sourceTree = "<group>"; };
 		1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsNetworkInteractionBuilder.swift; sourceTree = "<group>"; };
 		1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProtocol.swift; sourceTree = "<group>"; };
+		1A12D2CD25C825480022A73B /* DreamsNetworkInteracting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsNetworkInteracting.swift; sourceTree = "<group>"; };
 		1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamsLaunchingError.swift; sourceTree = "<group>"; };
 		1A4E0D8F25C0599A00D453B1 /* FakeResponseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeResponseMock.swift; sourceTree = "<group>"; };
 		1AA0023525C05FF4000C5883 /* MockNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigation.swift; sourceTree = "<group>"; };
@@ -125,6 +128,7 @@
 		FA343FE2251CDD950073F33E = {
 			isa = PBXGroup;
 			children = (
+				1A02FC0025C19DBC0080A67E /* Dreams.podspec */,
 				1AAC42D525B0AFE200A56457 /* README.md */,
 				FA343FEE251CDD950073F33E /* Sources */,
 				FA6CD8E02525EB2700E68FA7 /* Tests */,
@@ -146,6 +150,10 @@
 			children = (
 				FA343FF0251CDD950073F33E /* Info.plist */,
 				FA343FEF251CDD950073F33E /* Dreams.h */,
+				FAF52E03252F2FC90099D38F /* WebServiceType.swift */,
+				FAF52DFF252F2ADE0099D38F /* WebServiceDelegate.swift */,
+				1A12D2CD25C825480022A73B /* DreamsNetworkInteracting.swift */,
+				1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */,
 				FA482E9F251CE91F00D6006B /* Dreams.swift */,
 				1A0C2C8D25AC7FD900279C0C /* DreamsConfiguration.swift */,
 				1A0C2C9B25AC9C9100279C0C /* DreamsCredentials.swift */,
@@ -155,10 +163,7 @@
 				FA73781325876E5800B662F3 /* Request.swift */,
 				FA73781725876E7600B662F3 /* ResponseEvent.swift */,
 				FA6B49CD252356E80026B31D /* WebService.swift */,
-				FAF52E03252F2FC90099D38F /* WebServiceType.swift */,
-				FAF52DFF252F2ADE0099D38F /* WebServiceDelegate.swift */,
 				1A0C2CB325ADDA6C00279C0C /* DreamsNetworkInteractionBuilder.swift */,
-				1A0C2CCD25AF59A700279C0C /* WebViewProtocol.swift */,
 				1A4E0C7A25B87F5000D453B1 /* DreamsLaunchingError.swift */,
 			);
 			path = Sources;
@@ -303,6 +308,7 @@
 				FAF52E0A252F36A80099D38F /* DreamsDelegate.swift in Sources */,
 				FA73781425876E5800B662F3 /* Request.swift in Sources */,
 				FA482EA2251CE91F00D6006B /* Dreams.swift in Sources */,
+				1A12D2CE25C825480022A73B /* DreamsNetworkInteracting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/DreamsNetworkInteracting.swift
+++ b/Sources/DreamsNetworkInteracting.swift
@@ -1,0 +1,28 @@
+//
+//  DreamsNetworkInteracting
+//  Dreams
+//
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright © 2021 Dreams AB.
+//
+
+import Foundation
+
+// MARK: DreamsNetworkInteracting
+
+public protocol DreamsNetworkInteracting {
+    func didLoad()
+    func use(webView: WebViewProtocol)
+    func use(delegate: DreamsDelegate)
+    func launch(with credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?)
+    func update(locale: Locale)
+}
+
+extension DreamsNetworkInteracting {
+    func launch(with credentials: DreamsCredentials, locale: Locale) {
+        launch(with: credentials, locale: locale, completion: nil)
+    }
+}

--- a/Sources/DreamsNetworkInteraction.swift
+++ b/Sources/DreamsNetworkInteraction.swift
@@ -12,22 +12,6 @@
 import Foundation
 import WebKit
 
-// MARK: DreamsNetworkInteracting
-
-public protocol DreamsNetworkInteracting {
-    func didLoad()
-    func use(webView: WebViewProtocol)
-    func use(delegate: DreamsDelegate)
-    func launch(with credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?)
-    func update(locale: Locale)
-}
-
-extension DreamsNetworkInteracting {
-    func launch(with credentials: DreamsCredentials, locale: Locale) {
-        launch(with: credentials, locale: locale, completion: nil)
-    }
-}
-
 // MARK: DreamsNetworkInteraction
 
 public final class DreamsNetworkInteraction: DreamsNetworkInteracting {

--- a/Sources/DreamsNetworkInteraction.swift
+++ b/Sources/DreamsNetworkInteraction.swift
@@ -18,13 +18,15 @@ public final class DreamsNetworkInteraction: DreamsNetworkInteracting {
 
     private let webService: WebServiceType
     private let configuration: DreamsConfiguration
+    private let localeFormatter: LocaleFormatting
     
     private weak var webView: WebViewProtocol!
     private weak var delegate: DreamsDelegate?
     
-    init(configuration: DreamsConfiguration, webService: WebServiceType) {
+    init(configuration: DreamsConfiguration, webService: WebServiceType, localeFormatter: LocaleFormatting) {
         self.configuration = configuration
         self.webService = webService
+        self.localeFormatter = localeFormatter
     }
     
     // MARK: Public
@@ -100,7 +102,7 @@ public final class DreamsNetworkInteraction: DreamsNetworkInteracting {
         let body = [
             "token": credentials.idToken,
             "client_id": configuration.clientId,
-            "locale": locale.identifier,
+            "locale": localeFormatter.format(locale: locale, format: .bcp47),
         ]
         
         let verifyTokenURL = configuration.baseURL.appendingPathComponent("/users/verify_token")

--- a/Sources/DreamsNetworkInteractionBuilder.swift
+++ b/Sources/DreamsNetworkInteractionBuilder.swift
@@ -14,6 +14,7 @@ import Foundation
 public enum DreamsNetworkInteractionBuilder {
     static func build(configuration: DreamsConfiguration) -> DreamsNetworkInteracting & WebServiceDelegate {
         let webService = WebService()
-        return DreamsNetworkInteraction(configuration: configuration, webService: webService)
+        let localeFormatter = LocaleFormatter()
+        return DreamsNetworkInteraction(configuration: configuration, webService: webService, localeFormatter: localeFormatter)
     }
 }

--- a/Sources/LocaleFormatter.swift
+++ b/Sources/LocaleFormatter.swift
@@ -1,0 +1,33 @@
+//
+//  LocaleFormatter
+//  Dreams
+//
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright © 2021 Dreams AB.
+//
+
+import Foundation
+
+final class LocaleFormatter: LocaleFormatting {
+
+    private enum Constants {
+        static let hyphen: String = "-"
+    }
+
+    func format(locale: Locale, format: LocaleIdentifierFormat) -> String {
+        switch format {
+        case .bcp47:
+            return formatToBCP47(locale: locale)
+        case .osDefault:
+            return locale.identifier
+        }
+    }
+
+    private func formatToBCP47(locale: Locale) -> String {
+        let components = [locale.languageCode, locale.regionCode]
+        return components.compactMap({ $0 }).joined(separator: Constants.hyphen)
+    }
+}

--- a/Sources/LocaleFormatting.swift
+++ b/Sources/LocaleFormatting.swift
@@ -1,0 +1,21 @@
+//
+//  LocaleFormatting
+//  Dreams
+//
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright © 2021 Dreams AB.
+//
+
+import Foundation
+
+enum LocaleIdentifierFormat {
+    case osDefault // Default format on iOS
+    case bcp47 // ftp://ftp.isi.edu/in-notes/bcp/bcp47.txt
+}
+
+protocol LocaleFormatting {
+    func format(locale: Locale, format: LocaleIdentifierFormat) -> String
+}

--- a/Tests/LocaleFormatterTests.swift
+++ b/Tests/LocaleFormatterTests.swift
@@ -1,0 +1,58 @@
+//
+//  LocaleFormatterTests
+//  DreamsTests
+//
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright © 2021 Dreams AB.
+//
+
+import XCTest
+import WebKit
+@testable import Dreams
+
+final class LocaleFormatterTests: XCTestCase {
+
+    private var subject: LocaleFormatter!
+
+    override func setUpWithError() throws {
+        subject = LocaleFormatter()
+    }
+
+    func test_format_bcp47_only_language() {
+        let locale = Locale(identifier: "sv")
+        let formatted = subject.format(locale: locale, format: .bcp47)
+
+        XCTAssertEqual(formatted, "sv")
+    }
+
+    func test_format_bcp47_languageAndRegion() {
+        let locale = Locale(identifier: "sv_SE")
+        let formatted = subject.format(locale: locale, format: .bcp47)
+
+        XCTAssertEqual(formatted, "sv-SE")
+    }
+
+    func test_format_osDefault_only_language() {
+        let locale = Locale(identifier: "sv")
+        let formatted = subject.format(locale: locale, format: .osDefault)
+
+        XCTAssertEqual(formatted, "sv")
+    }
+
+    func test_format_osDefault_underscore_languageAndRegion() {
+        let locale = Locale(identifier: "sv_SE")
+        let formatted = subject.format(locale: locale, format: .osDefault)
+
+        XCTAssertEqual(formatted, "sv_SE")
+    }
+
+    func test_format_osDefault_dash_languageAndRegion() {
+        let locale = Locale(identifier: "sv-SE")
+        let formatted = subject.format(locale: locale, format: .osDefault)
+
+        XCTAssertEqual(formatted, "sv-SE")
+    }
+}

--- a/Tests/Mocks/LocaleFormattingMock.swift
+++ b/Tests/Mocks/LocaleFormattingMock.swift
@@ -1,0 +1,28 @@
+//
+//  LocaleFormattingMock
+//  Dreams
+//
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright © 2021 Dreams AB.
+//
+
+import Foundation
+@testable import Dreams
+
+final class LocaleFormatterMock: LocaleFormatting {
+
+    var returnString: String = ""
+
+    var localesGiven: [Locale] = []
+    var formatsGiven: [LocaleIdentifierFormat] = []
+
+    func format(locale: Locale, format: LocaleIdentifierFormat) -> String {
+        localesGiven.append(locale)
+        formatsGiven.append(format)
+
+        return returnString
+    }
+}


### PR DESCRIPTION
- 🚀 added and used `LocaleFormatter` with locale identifier format BCP47
- 🏕️ moved `DreamsNetworkInteracting` protocol to a separate file 