### PR TITLE
feat: add content type json to headers

### DIFF
--- a/Sources/WebService.swift
+++ b/Sources/WebService.swift
@@ -16,6 +16,11 @@ typealias JSONObject = [String: Any]
 
 final class WebService: NSObject, WebServiceType {
 
+    private enum Constants {
+        static let jsonMimetype = "application/json"
+        static let headerContentType = "Content-Type"
+    }
+
     var delegate: WebServiceDelegate?
     
     private var completion: ((Result<Void, DreamsLaunchingError>) -> Void)?
@@ -31,6 +36,8 @@ final class WebService: NSObject, WebServiceType {
         
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method
+        urlRequest.addValue(Constants.jsonMimetype,
+                            forHTTPHeaderField: Constants.headerContentType)
 
         if let httpBody = body {
             urlRequest.httpBody = try? JSONSerialization.data(withJSONObject: httpBody)

--- a/Tests/WebServiceTests.swift
+++ b/Tests/WebServiceTests.swift
@@ -34,6 +34,7 @@ class WebServiceTests: XCTestCase {
         let event = spyDelegate.events.last
         let request = event?["request"] as! URLRequest
 
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
         XCTAssertEqual(request.url, mockURL)
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(request.httpBody, try! JSONSerialization.data(withJSONObject: ["test": "test"]))


### PR DESCRIPTION
- New Header field:  `Content-Type: application/json`
- Covered by unit test check

