### PR TITLE
[CN-273] Present share interface on `share` js call

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,6 @@
 platform :ios, '14.0'
 use_frameworks!
 target 'Example' do
-    pod 'Dreams'
+    pod 'Dreams', :path => '../'
 end
 

--- a/Sources/DreamsNetworkInteracting.swift
+++ b/Sources/DreamsNetworkInteracting.swift
@@ -16,6 +16,7 @@ import Foundation
 public protocol DreamsNetworkInteracting {
     func didLoad()
     func use(webView: WebViewProtocol)
+    func use(navigation: ViewControllerPresenting)
     func use(delegate: DreamsDelegate)
     func launch(with credentials: DreamsCredentials, locale: Locale, completion: ((Result<Void, DreamsLaunchingError>) -> Void)?)
     func update(locale: Locale)

--- a/Sources/DreamsViewController.swift
+++ b/Sources/DreamsViewController.swift
@@ -56,6 +56,13 @@ public protocol DreamsDelegateUsing: class {
     func use(delegate: DreamsDelegate)
 }
 
+public protocol ViewControllerPresenting: class {
+    /**
+     This method is used internally.
+     */
+    func present(viewController: UIViewController)
+}
+
 public class DreamsViewController: UIViewController {
 
     private lazy var webView: WKWebView = {
@@ -94,6 +101,7 @@ public class DreamsViewController: UIViewController {
     
     public override func viewDidLoad() {
         interaction.didLoad()
+        interaction.use(navigation: self)
     }
     
 }
@@ -140,5 +148,12 @@ extension DreamsViewController: LocaleUpdating {
      */
     public func update(locale: Locale) {
         interaction.update(locale: locale)
+    }
+}
+
+// MARK: ViewControllerPresenting (used internally)
+extension DreamsViewController: ViewControllerPresenting {
+    public func present(viewController: UIViewController) {
+        present(viewController, animated: true, completion: nil)
     }
 }

--- a/Sources/ResponseEvent.swift
+++ b/Sources/ResponseEvent.swift
@@ -19,4 +19,5 @@ enum ResponseEvent: String, CaseIterable {
     case onTelemetryEvent
     case onAccountProvisionRequested
     case onExitRequested
+    case share
 }

--- a/Tests/DreamsViewControllerTests.swift
+++ b/Tests/DreamsViewControllerTests.swift
@@ -42,6 +42,9 @@ class DreamsViewControllerTests: XCTestCase {
         
         XCTAssertEqual(interaction.useWebViews.count, 1)
         XCTAssertTrue(interaction.useWebViews.first === view)
+
+        XCTAssertEqual(interaction.useNavigations.count, 1)
+        XCTAssertTrue(interaction.useNavigations.first === subject)
     }
     
     func testUseDelegate() {

--- a/Tests/Spies/DreamsNetworkInteractingSpy.swift
+++ b/Tests/Spies/DreamsNetworkInteractingSpy.swift
@@ -17,6 +17,7 @@ final class DreamsNetworkInteractingSpy: DreamsNetworkInteracting {
     var didLoadCount: Int = 0
     var useWebViews: [WebViewProtocol] = []
     var useDelegates: [DreamsDelegate] = []
+    var useNavigations: [ViewControllerPresenting] = []
     var launchCredentials: [DreamsCredentials] = []
     var completions: [((Result<Void, DreamsLaunchingError>) -> Void)] = []
     var launchLocales: [Locale] = []
@@ -44,5 +45,9 @@ final class DreamsNetworkInteractingSpy: DreamsNetworkInteracting {
     
     func update(locale: Locale) {
         updateLocales.append(locale)
+    }
+
+    func use(navigation: ViewControllerPresenting) {
+        useNavigations.append(navigation)
     }
 }


### PR DESCRIPTION
**JavaScript example to trigger the share:**

```javascript
var payload = {"text":"Text to share", "url": "https://getdreams.com"};
if (window.JSBridge) {
    window.JSBridge.share(payload);
}
if (window.webkit) {
    window.webkit.messageHandlers.share(payload);
}
```